### PR TITLE
Extend data point for alarm panel

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -509,6 +509,22 @@
             }
         },
         {
+            "_id": "control.alarm.arm_state",
+            "type": "state",
+            "common": {
+                "name": "arm status",
+                "type": "string",
+                "desc": "Alarm arm status",
+                "states": {
+                    "alarm_arm_home": "alarm_arm_home",
+                    "alarm_arm_away": "alarm_arm_away",
+                    "alarm_arm_night": "alarm_arm_night",
+                    "alarm_arm_custom_bypass": "alarm_arm_custom_bypass",
+                    "alarm_disarm": "alarm_disarm"
+                }
+            }
+        },
+        {
             "_id": "control.theme",
             "type": "state",
             "common": {

--- a/io-package.json
+++ b/io-package.json
@@ -499,7 +499,7 @@
             "common": {
                 "name": "alarm",
                 "type": "boolean",
-                "write": true,
+                "write": false,
                 "read": true,
                 "desc": "Arm or disarm with code",
                 "def": false
@@ -514,6 +514,8 @@
             "common": {
                 "name": "arm status",
                 "type": "string",
+                "write": false,
+                "read": true,
                 "desc": "Alarm arm status",
                 "states": {
                     "alarm_arm_home": "alarm_arm_home",

--- a/lib/server.js
+++ b/lib/server.js
@@ -675,12 +675,18 @@ class WebServer {
             //  alarm_arm_away, alarm_arm_home, alarm_arm_night, alarm_arm_custom_bypass, alarm_disarm (code will be sent)
             this.log.debug(data.service + ': ' + id + ' = ' + data.service_data.code ? 'XXX' : 'none');
             this.adapter.getForeignObject(id, (err, obj) => {
-                if (obj.native.alarm_code && obj.native.alarm_code.toString() !== data.service_data.code.toString()) {
+                this.log.debug("native" + JSON.stringify(obj.native));
+                if (data.service_data == null || data.service_data.code == null) {
+                    this._sendResponse(ws, data.id, {result: false, error: 'code is empty'});
+                } else if (!obj.native.alarm_code || !data.service_data.code) {
+                    this.log.warn(`No code is defined! To provide the code add to object ${id} native.alarm_code with desired code`);
+                } else if (obj.native.alarm_code.toString() !== data.service_data.code.toString()) {
                     this._sendResponse(ws, data.id, {result: false, error: 'invalid code'});
                 } else {
-                    this.log.warn(`No code is defined! To provide the code add to object ${id} native.alarm_code with desired code`);
-                    this.adapter.setForeignState(id, data.service.startsWith('alarm_arm'), false, {user}, () =>
-                        this._sendResponse(ws, data.id));
+                    this.adapter.setForeignState(id + '.arm_state', data.service, false, {user}, () => {
+                        this.adapter.setForeignState(id, data.service.startsWith('alarm_arm'), false, {user}, () =>
+                            this._sendResponse(ws, data.id));
+                    });
                 }
             });
         } else if (data.service.endsWith('_say')) {


### PR DESCRIPTION
Added datapoint arm_state for alarm centre, this contains the exact status (alarm_arm_home, alarm_arm_away, alarm_arm_night, alarm_arm_custom_bypass, alarm_disarm)
The controller crashed when trying to activate/deactivate the alarm. This error is now fixed.
